### PR TITLE
Handle empty config files gracefully

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,19 @@
+import logging
+import os
+import sys
+
+# Ensure the project root is on sys.path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from youtube_playlist_cli import Config
+
+def test_empty_config_load(tmp_path, caplog):
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("")
+    with caplog.at_level(logging.WARNING):
+        config = Config(str(cfg_file))
+        # No warning should be logged
+        assert "Error loading config" not in caplog.text
+        # Config should fall back to defaults
+        assert config.get("api_key") == ""
+        assert config.get("max_playlists") == 100

--- a/youtube_playlist_cli.py
+++ b/youtube_playlist_cli.py
@@ -66,7 +66,7 @@ class Config:
         if os.path.exists(self.config_file):
             try:
                 with open(self.config_file, 'r') as f:
-                    loaded = yaml.safe_load(f)
+                    loaded = yaml.safe_load(f) or {}
                     # Merge with defaults
                     config = self.DEFAULT_CONFIG.copy()
                     config.update(loaded)


### PR DESCRIPTION
## Summary
- Avoid warnings when loading an empty config file by defaulting to an empty dict
- Add regression test for loading empty configuration files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b623ad40c832589fb49d564ac8ae6