### PR TITLE
Centralize configuration handling across interfaces

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,78 @@
+import json
+import yaml
+import logging
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "api_key": "",
+    "max_playlists": 100,
+    "cache_enabled": True,
+    "cache_dir": ".cache",
+    "output_dir": "results",
+    "parallel_search": True,
+    "export_formats": ["json", "html"],
+    "search_strategies": [
+        "exact_title",
+        "channel_playlists",
+        "title_channel",
+        "keyword_search",
+    ],
+}
+
+def save_config(file_path: str, config: Dict[str, Any]) -> None:
+    """Save configuration to a YAML or JSON file."""
+    path = Path(file_path)
+    try:
+        with path.open("w") as f:
+            if path.suffix.lower() in {".yaml", ".yml"}:
+                yaml.dump(config, f, default_flow_style=False)
+            elif path.suffix.lower() == ".json":
+                json.dump(config, f, indent=2)
+            else:
+                raise ValueError("Unsupported config format: %s" % path.suffix)
+    except Exception as e:
+        logging.error(f"Error saving config: {e}")
+
+def load_config(file_path: str, defaults: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Load configuration from a YAML or JSON file and merge with defaults."""
+    path = Path(file_path)
+    data: Dict[str, Any] = {}
+    if path.exists():
+        try:
+            with path.open("r") as f:
+                if path.suffix.lower() in {".yaml", ".yml"}:
+                    data = yaml.safe_load(f) or {}
+                elif path.suffix.lower() == ".json":
+                    data = json.load(f)
+                else:
+                    raise ValueError("Unsupported config format: %s" % path.suffix)
+        except Exception as e:
+            logging.warning(f"Error loading config: {e}")
+            data = {}
+    if defaults:
+        merged = defaults.copy()
+        merged.update(data)
+        return merged
+    return data
+
+class Config:
+    """Simple configuration manager."""
+
+    def __init__(self, file_path: str = "config.yaml", defaults: Optional[Dict[str, Any]] = None):
+        self.file_path = file_path
+        self.defaults = defaults or DEFAULT_CONFIG
+        if not Path(self.file_path).exists():
+            save_config(self.file_path, self.defaults)
+        self.config = load_config(self.file_path, self.defaults)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.config.get(key, default)
+
+    def set(self, key: str, value: Any, autosave: bool = True) -> None:
+        self.config[key] = value
+        if autosave:
+            self.save()
+
+    def save(self) -> None:
+        save_config(self.file_path, self.config)

--- a/gui_config-sample.json
+++ b/gui_config-sample.json
@@ -1,6 +1,0 @@
-{
-  "api_key": "YOUR_YOUTUBE_API_KEY_HERE",
-  "max_playlists": 100,
-  "cache_enabled": true,
-  "parallel_search": true
-}

--- a/readme.md
+++ b/readme.md
@@ -59,12 +59,13 @@ pip install -r requirements.txt
 ### 3. Set up your API key
 
 #### Option A: Using configuration file
-Create a `config.yaml` file:
+Both interfaces read settings from `config.yaml`. Copy `config-sample.yaml` and edit:
 ```yaml
 api_key: "YOUR_YOUTUBE_API_KEY_HERE"
 max_playlists: 100
 cache_enabled: true
 ```
+YAML is the canonical format; a JSON file (`config.json`) is also accepted.
 
 #### Option B: Environment variable
 ```bash
@@ -246,7 +247,8 @@ youtube-playlist-finder/
 ├── youtube_playlist_cli.py     # Command-line interface
 ├── youtube_playlist_gui.py     # Graphical interface
 ├── requirements.txt            # Python dependencies
-├── config.yaml                # Configuration file
+├── config-sample.yaml         # Example configuration
+├── config.yaml                # User configuration
 ├── README.md                  # Documentation
 ├── .cache/                    # Cache directory (auto-created)
 ├── results/                   # Output directory (auto-created)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ import os
 import sys
 import subprocess
 import platform
-import json
 import yaml
 from pathlib import Path
 
@@ -121,19 +120,6 @@ class Setup:
             
             print(f"✅ API key saved to {config_file}")
             
-            # Also save for GUI
-            gui_config = self.project_root / "gui_config.json"
-            gui_config_data = {
-                "api_key": api_key,
-                "max_playlists": 100,
-                "cache_enabled": True,
-                "parallel_search": True
-            }
-            
-            with open(gui_config, 'w') as f:
-                json.dump(gui_config_data, f, indent=2)
-            
-            print(f"✅ GUI config saved to {gui_config}")
             return True
         else:
             print("⚠️ No API key provided. You'll need to set it later.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ import sys
 # Ensure the project root is on sys.path
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from youtube_playlist_cli import Config
+from config import Config
 
 def test_empty_config_load(tmp_path, caplog):
     cfg_file = tmp_path / "config.yaml"

--- a/youtube_playlist_cli.py
+++ b/youtube_playlist_cli.py
@@ -7,9 +7,8 @@ import os
 import sys
 import argparse
 import json
-import yaml
 import logging
-from typing import Dict, List, Optional
+from typing import List, Optional
 from datetime import datetime
 from pathlib import Path
 
@@ -38,63 +37,7 @@ except ImportError:
     sys.exit(1)
 
 
-class Config:
-    """Configuration management."""
-    
-    DEFAULT_CONFIG = {
-        "api_key": "",
-        "max_playlists": 100,
-        "cache_enabled": True,
-        "cache_dir": ".cache",
-        "output_dir": "results",
-        "parallel_search": True,
-        "export_formats": ["json", "html"],
-        "search_strategies": [
-            "exact_title",
-            "channel_playlists",
-            "title_channel",
-            "keyword_search"
-        ]
-    }
-    
-    def __init__(self, config_file: str = "config.yaml"):
-        self.config_file = config_file
-        self.config = self.load()
-    
-    def load(self) -> Dict:
-        """Load configuration from file."""
-        if os.path.exists(self.config_file):
-            try:
-                with open(self.config_file, 'r') as f:
-                    loaded = yaml.safe_load(f) or {}
-                    # Merge with defaults
-                    config = self.DEFAULT_CONFIG.copy()
-                    config.update(loaded)
-                    return config
-            except Exception as e:
-                logging.warning(f"Error loading config: {e}")
-        
-        # Create default config
-        self.save(self.DEFAULT_CONFIG)
-        return self.DEFAULT_CONFIG.copy()
-    
-    def save(self, config: Dict = None):
-        """Save configuration to file."""
-        config = config or self.config
-        try:
-            with open(self.config_file, 'w') as f:
-                yaml.dump(config, f, default_flow_style=False)
-        except Exception as e:
-            logging.error(f"Error saving config: {e}")
-    
-    def get(self, key: str, default=None):
-        """Get configuration value."""
-        return self.config.get(key, default)
-    
-    def set(self, key: str, value):
-        """Set configuration value."""
-        self.config[key] = value
-        self.save()
+from config import Config
 
 
 class CLIInterface:

--- a/youtube_playlist_gui.py
+++ b/youtube_playlist_gui.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from typing import List, Dict, Optional
 import logging
 from pathlib import Path
+from config import Config
 
 
 logger = logging.getLogger(__name__)
@@ -127,6 +128,7 @@ class YouTubePlaylistFinderGUI:
         self.finder = None
         self.current_results = []
         self.current_video_info = None
+        self.config = Config()
         
         # Search strategies
         self.strategy_vars = {
@@ -1009,30 +1011,19 @@ How to use:
         return None
     
     def load_config(self):
-        """Load configuration from file."""
-        config_file = "gui_config.json"
-        if os.path.exists(config_file):
-            try:
-                with open(config_file, 'r') as f:
-                    config = json.load(f)
-                    self.api_key.set(config.get('api_key', ''))
-                    self.max_playlists.set(config.get('max_playlists', 100))
-                    self.cache_enabled.set(config.get('cache_enabled', True))
-                    self.parallel_search.set(config.get('parallel_search', True))
-            except Exception as e:
-                logger.error("Failed to load GUI config: %s", e)
-    
-    def save_config(self):
-        """Save configuration to file."""
-        config = {
-            'api_key': self.api_key.get(),
-            'max_playlists': self.max_playlists.get(),
-            'cache_enabled': self.cache_enabled.get(),
-            'parallel_search': self.parallel_search.get()
-        }
+        """Load configuration from shared config file."""
+        self.api_key.set(self.config.get('api_key', ''))
+        self.max_playlists.set(self.config.get('max_playlists', 100))
+        self.cache_enabled.set(self.config.get('cache_enabled', True))
+        self.parallel_search.set(self.config.get('parallel_search', True))
 
-        with open("gui_config.json", 'w') as f:
-            json.dump(config, f, indent=2)
+    def save_config(self):
+        """Persist configuration to shared config file."""
+        self.config.set('api_key', self.api_key.get(), autosave=False)
+        self.config.set('max_playlists', self.max_playlists.get(), autosave=False)
+        self.config.set('cache_enabled', self.cache_enabled.get(), autosave=False)
+        self.config.set('parallel_search', self.parallel_search.get(), autosave=False)
+        self.config.save()
         logger.info("GUI configuration saved")
     
     def center_window(self):


### PR DESCRIPTION
## Summary
- add `config.py` with YAML/JSON load and save helpers plus a simple `Config` manager
- refactor CLI and GUI to use the shared configuration module
- consolidate example and documentation to YAML configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b68789fb0832581dfd91d63c061e4