### PR TITLE
Ensure minimum results for popular playlist search

### DIFF
--- a/youtube_playlist_core.py
+++ b/youtube_playlist_core.py
@@ -514,10 +514,11 @@ class PlaylistFinder:
         elif strategy == SearchStrategy.POPULAR_PLAYLISTS:
             # Search for popular compilation playlists
             queries = ["best of", "compilation", "mix", "playlist"]
+            results_per_query = max(1, max_results // len(queries))  # Guard against zero results
             for query in queries:
                 ids = self.api.search_playlists(
                     f"{query} {video_info.channel_title}",
-                    max_results // len(queries)
+                    results_per_query
                 )
                 playlist_ids.extend(ids)
         


### PR DESCRIPTION
## Summary
- Avoid passing zero results per query in popular playlist search strategy by computing a guarded `results_per_query`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b77b52314832586e75d4622000a56