### PR TITLE
Fix cache save locking to avoid deadlock

### DIFF
--- a/youtube_playlist_core.py
+++ b/youtube_playlist_core.py
@@ -132,9 +132,11 @@ class CacheManager:
                 'timestamp': datetime.now().isoformat()
             }
             logging.debug("Cache set for key %s", key)
-            # Save periodically
-            if len(self.cache) % 10 == 0:
-                self._save_cache()
+            # Determine if we should save while holding the lock
+            should_save = len(self.cache) % 10 == 0
+
+        if should_save:
+            self._save_cache()
     
     def get_stats(self) -> Dict:
         """Get cache statistics."""


### PR DESCRIPTION
## Summary
- Compute whether the cache should be saved while holding the lock in `CacheManager.set`
- Release the lock and conditionally persist cache to disk

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b8bc917388325914d60fb4fdbdffa